### PR TITLE
Update included test suite to properly render app.

### DIFF
--- a/src/__tests__/app.test.jsx
+++ b/src/__tests__/app.test.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import app from 'app';
+import Routes from '../routes';
 
 configure({ adapter: new Adapter() });
 
 describe('app', () => {
   it('renders without crashing', () => {
-    mount(<app />);
+    mount(<Routes />);
   });
 });


### PR DESCRIPTION
The included test did not run properly, as it did not render the App component because it was imported in lower case (as `app`). Simply rendering the app component properly (as `App`) caused a myriad of errors, including the need for the app to be rendered within the Router component.

TLDR: Fixed the included test by swapping out `App` for `Router`, as this fully renders the app.