### PR TITLE
Fix: react-hot-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "loglevel": "^1.6.0",
     "node-sass": "^4.7.2",
     "postcss-loader": "^2.0.9",
-    "react-hot-loader": "^3.1.3",
+    "react-hot-loader": "^4.0.0",
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^4.0.8",
     "react-test-renderer": "^16.2.0",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,22 +3,20 @@ import ReactDOM from 'react-dom'
 import {AppContainer} from 'react-hot-loader'
 import Routes from './routes'
 
-ReactDOM.render(
-  <AppContainer>
-      <Routes />
-  </AppContainer>,
-  document.getElementById('app')
-);
+const renderApp = (Component) => {
+  ReactDOM.render(
+    <AppContainer>
+      <Component/>
+    </AppContainer>,
+    document.getElementById('app')
+  );
+};
 
-// Hot Module Replacement API
+renderApp(Routes);
+
+// Webpack Hot Module Replacement API
 if (module.hot) {
-  module.hot.accept('./app', () => {
-    const NextApp = require('./app').default;
-    ReactDOM.render(
-      <AppContainer>
-        <NextApp/>
-      </AppContainer>,
-      document.getElementById('app')
-    );
-  });
+  module.hot.accept('./routes', () => {
+    renderApp(require('./routes').default);
+  })
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,6 @@ module.exports = {
     'core-js/es6/object',
     'core-js/es6/array',
 
-    'react-hot-loader/patch',
     './src/index.jsx', // your app's entry point
   ],
   devtool: process.env.WEBPACK_DEVTOOL || 'eval-source-map',

--- a/webpack.loaders.js
+++ b/webpack.loaders.js
@@ -13,6 +13,7 @@ const sassResourcesPaths = [
   path.resolve(__dirname, 'styles/abstracts/_mixins.sass'),
 ];
 
+// noinspection WebpackConfigHighlighting
 module.exports = [
   // =========
   // = Babel =
@@ -22,7 +23,14 @@ module.exports = [
   {
     test: /\.jsx?$/,
     include: path.resolve(__dirname, 'src'),
-    loader: ["babel-loader"]
+    loader: "babel-loader",
+    options: {
+      // This is a feature of `babel-loader` for Webpack (not Babel itself).
+      // It enables caching results in ./node_modules/.cache/babel-loader/
+      // directory for faster rebuilds.
+      cacheDirectory: true,
+      plugins: ['react-hot-loader/babel'],
+    }
   },
   // =========
   // = Fonts =


### PR DESCRIPTION
PR to make hot-reload finally works.

I've been using this starter for a while and for me the hot-reloading never worked, until now a full page reload was needed.

With this PR the hot-reload should finally work.

- migrated to react-hot-loader v4
- removed react-hot-loader/patch from Webpack config because it's [not needed anymore ](https://github.com/gaearon/react-hot-loader/#no-patch-required)
- added babel-loader config for hot reloading
- modified app entry point to work with hot-reloading